### PR TITLE
Correção de Inicialização da 3.2.7

### DIFF
--- a/lib/config/Backups/.ignore.txt
+++ b/lib/config/Backups/.ignore.txt
@@ -1,0 +1,1 @@
+Arquivo 'vazio' para evitar que a GitHub mande o commit com uma pasta faltando.

--- a/lib/functions/works.js
+++ b/lib/functions/works.js
@@ -20,7 +20,7 @@ exports.checkUpdate = async () => {
 	await axios.get('https://raw.githubusercontent.com/KillovSky/iris/dev/package.json').then(last => {
 		if (atualIris.version !== last.data.version) {
 			console.log(tools('others').color('[UPDATE]', 'crimson'), tools('others').color(`Uma nova versão da Íris foi lançada [${last.data.version}], atualize para obter melhorias e correções! → ${last.data.homepage}`, 'gold')+'\n')
-		} else console.log(tools('others').color('[IRIS ${atualIris.version}]', 'magenta'), tools('others').color('Parabéns por manter me manter atualizada <3', 'lime')+'\n')
+		} else console.log(tools('others').color(`[IRIS ${atualIris.version}]`, 'magenta'), tools('others').color('Parabéns por manter me manter atualizada <3', 'lime')+'\n')
 	}).catch(err => {
 		let sessionLog_Name = `./logs/Session_Logs/${moment().format('DD-MM-YY # HH-mm-ss')} - ${tools('others').randomString(5)}.txt`
 		console.log(`Checagem de versão falhou, de uma olhada no arquivo de Logs -> ${sessionLog_Name}`)


### PR DESCRIPTION
Corrige o erro da inicialização, foi causado pela Git Desktop ignorar a pasta vazia, creio que esteja funcional após aplicar este patch.